### PR TITLE
Provide an option :run_at_start to control if run annotate at guard start

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -33,7 +33,7 @@ Please read the {Guard usage docs}[https://github.com/guard/guard#readme]
       # a model file changes
       #watch( 'app/models/**/*.rb' )
     end
-    
+
 
 == Options
 
@@ -48,16 +48,22 @@ You can customize the placement of the annotations with (default is 'before'):
     guard 'annotate', :position => 'before|after' do
       ...
     end
-    
+
 You can choose to also annotate your routes file with (default is false):
-    
+
     guard 'annotate', :routes => true do
       ...
     end
-    
+
 You can annotate your tests and fixtures files with (default is false):
 
     guard 'annotate', :tests => true do
+      ...
+    end
+
+You can disable run at start with (default is true):
+
+    guard 'annotate', :run_at_start => false do
       ...
     end
 

--- a/lib/guard/annotate.rb
+++ b/lib/guard/annotate.rb
@@ -4,20 +4,21 @@ require 'guard/guard'
 
 module Guard
   class Annotate < Guard
-    
+
     autoload :Notifier, 'guard/annotate/notifier'
-    
+
     def initialize( watchers=[], options={} )
       super
-      
+
       options[:notify] = true if options[:notify].nil?
       options[:position] = 'before' if options[:position].nil?
       options[:tests] = false if options[:tests].nil?
       options[:routes] = false if options[:routes].nil?
+      options[:run_at_start] = true if options[:run_at_start].nil?
     end
 
     def start
-      run_annotate
+      run_annotate if options[:run_at_start]
     end
 
     def stop
@@ -35,25 +36,25 @@ module Guard
     def run_on_change( paths=[] )
       run_annotate
     end
-    
+
     private
-    
+
     def notify?
       !!options[:notify]
     end
-    
+
     def annotation_position
       options[:position]
     end
-    
+
     def annotate_routes?
       options[:routes]
     end
-    
+
     def annotate_tests_flags
       options[:tests] ? "" : "--exclude tests,fixtures"
     end
-    
+
     def run_annotate
       UI.info 'Running annotate', :reset => true
       started_at = Time.now
@@ -65,7 +66,7 @@ module Guard
         @result = system("bundle exec annotate -r")
         Notifier::notify( @result, Time.now - started_at ) if notify?
       end
-      
+
       @result
     end
   end

--- a/spec/guard/annotate_spec.rb
+++ b/spec/guard/annotate_spec.rb
@@ -2,13 +2,13 @@ require 'spec_helper'
 
 describe Guard::Annotate do
   subject { Guard::Annotate.new }
-  
+
   context "#initialize options" do
     describe "notify" do
       it "should be true by default" do
         subject.should be_notify
       end
-      
+
       it "should allow notifications to be turned off" do
         subject = Guard::Annotate.new( [], :notify => false )
         subject.options[:notify].should be_false
@@ -17,7 +17,7 @@ describe Guard::Annotate do
       it "should use 'before' position by default" do
         subject.options[:position].should == 'before'
       end
-      
+
       it "should allow user to customize position (before)" do
         subject = Guard::Annotate.new( [], :position => 'before' )
         subject.options[:position].should == 'before'
@@ -31,24 +31,24 @@ describe Guard::Annotate do
         subject.should_receive(:system).with("bundle exec annotate --exclude tests,fixtures -p after")
         subject.start
       end
-      
+
       describe "routes" do
         it "should not run routes by default" do
           subject.options[:routes].should be_false
         end
-        
+
         it "should allow the users to run routes if desired" do
           subject = Guard::Annotate.new( [], :routes => true)
           subject.should_receive(:system).twice
           subject.start
         end
       end
-      
+
       describe "tests & fixtures" do
         it "should not run tests annotations by default" do
           subject.options[:tests].should be_false
         end
-        
+
         it "should allo user to run tests and fixtures annotations if desired" do
           subject = Guard::Annotate.new( [], :tests => true )
           subject.should_receive(:system).with("bundle exec annotate  -p before")
@@ -57,49 +57,55 @@ describe Guard::Annotate do
       end
     end
   end
-  
+
   context "start" do
     it "should run annotate command" do
       subject.should_receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before")
       subject.start
     end
-    
+
     it "should return false if annotate command fails" do
       subject.should_receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before").and_return(false)
       subject.start.should be_false
     end
+
+    it 'should not run annotate command if disabled :run_at_start' do
+      subject.should_not_receive(:system)
+      subject.options[:run_at_start] = false
+      subject.start
+    end
   end
-  
+
   context "stop" do
     it "should be a noop (return true)" do
       subject.stop.should be_true
     end
-  end  
-  
+  end
+
   context "run_all" do
     it "should be a noop (return true)" do
       subject.run_all.should be_true
     end
-  end  
-  
+  end
+
   context "reload" do
     it "should run annotate command" do
       subject.should_receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before")
       subject.reload
     end
-    
+
     it "should return false if annotate command fails" do
       subject.should_receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before").and_return(false)
       subject.reload.should be_false
     end
   end
-  
+
   context "run_on_change" do
     it "should run annotate command" do
       subject.should_receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before")
       subject.run_on_change
     end
-    
+
     it "should return false if annotate command fails" do
       subject.should_receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before").and_return(false)
       subject.run_on_change.should be_false


### PR DESCRIPTION
Run annotate at start often not necessary, so I provided an option to disable it.
