### PR TITLE
Fixed AnnotateVersion exception

### DIFF
--- a/lib/guard/annotate.rb
+++ b/lib/guard/annotate.rb
@@ -42,7 +42,7 @@ module Guard
     def run_on_changes(paths=[])
       run_annotate
     end
-    alias :run_on_change :run_on_changes if Guard::AnnotateVersion::VERSION < '1.1.0'
+    alias :run_on_change :run_on_changes if ::Guard::AnnotateVersion::VERSION < '1.1.0'
 
     private
 


### PR DESCRIPTION
Fixed `/gems/guard-annotate-2.0.1/lib/guard/annotate.rb:45:in`class:Annotate': uninitialized constant Guard::Guard::AnnotateVersion (NameError)`
