### PR TITLE
update to use Guard::Compat

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,19 @@
 source "http://rubygems.org"
 
 # Specify your gem's dependencies in guard-annotate.gemspec
-gemspec
+gemspec development_group: :gem_build_tools
+
+group :gem_build_tools do
+  gem 'rake', '~> 0.9.2.2'
+end
+
+group :development do
+  gem 'guard-rspec', '~> 0.6.0'
+end
+
+group :test do
+  gem  'rspec', '~> 2.9.0'
+end
 
 require './spec/support/platform_helper'
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ group :development do
 end
 
 group :test do
-  gem  'rspec', '~> 2.9.0'
+  gem  'rspec', '~> 3.1'
 end
 
 require './spec/support/platform_helper'

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ end
 
 group :development do
   gem 'guard-rspec', '~> 0.6.0'
+  gem 'transpec'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ end
 
 group :development do
   gem 'guard-rspec', '~> 0.6.0'
-  gem 'transpec'
 end
 
 group :test do

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,11 @@
-require 'bundler'
+require 'bundler/gem_tasks'
 Bundler::GemHelper.install_tasks
 
 require 'rspec/core/rake_task'
-RSpec::Core::RakeTask.new( :spec )
+RSpec::Core::RakeTask.new( :spec ) do |t|
+  t.verbose = false
+end
+
 task :default => :spec
 
 namespace( :spec ) do

--- a/guard-annotate.gemspec
+++ b/guard-annotate.gemspec
@@ -15,12 +15,10 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "guard-annotate"
 
-  s.add_dependency 'guard', '~> 2.0'
+  s.add_dependency 'guard-compat', '~> 1.2.1'
   s.add_dependency 'annotate', '~> 2.4', '>= 2.4.0'
 
-  s.add_development_dependency 'rspec', '~> 2.9.0'
-  s.add_development_dependency 'guard-rspec', '~> 0.6.0'
-  s.add_development_dependency 'rake', '~> 0.9.2.2'
+  s.add_development_dependency 'bundler', '~> 1.6'
 
   s.files = Dir.glob('{lib}/**/*') + %w[LICENSE README.rdoc]
   s.require_paths = ["lib"]

--- a/guard-annotate.gemspec
+++ b/guard-annotate.gemspec
@@ -15,7 +15,8 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "guard-annotate"
 
-  s.add_dependency 'guard-compat', '~> 1.2.1'
+  s.add_dependency 'guard', '~> 2.6.1'
+  #s.add_dependency 'guard-compat', '~> 1.2.1'
   s.add_dependency 'annotate', '~> 2.4', '>= 2.4.0'
 
   s.add_development_dependency 'bundler', '~> 1.6'

--- a/guard-annotate.gemspec
+++ b/guard-annotate.gemspec
@@ -15,8 +15,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "guard-annotate"
 
-  s.add_dependency 'guard', '~> 2.6.1'
-  #s.add_dependency 'guard-compat', '~> 1.2.1'
+  s.add_dependency 'guard-compat', '~> 1.2.1'
   s.add_dependency 'annotate', '~> 2.4', '>= 2.4.0'
 
   s.add_development_dependency 'bundler', '~> 1.6'

--- a/lib/guard/annotate.rb
+++ b/lib/guard/annotate.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
-require 'guard'
-require 'guard/plugin'
+require 'guard/compat/plugin'
 require 'guard/annotate/version'
 
 module Guard
@@ -87,7 +86,7 @@ module Guard
     end
 
     def run_annotate
-      UI.info 'Running annotate', :reset => true
+      Compat::UI.info 'Running annotate', :reset => true
       started_at = Time.now
       annotate_models_options, annotate_options = '', ''
 

--- a/lib/guard/annotate/notifier.rb
+++ b/lib/guard/annotate/notifier.rb
@@ -2,7 +2,7 @@
 module Guard
   class Annotate
     class Notifier
-      
+
       class << self
         def guard_message( result, duration )
           case result
@@ -12,19 +12,19 @@ module Guard
             "Annotate run has failed!\nPlease check manually."
           end
         end
-        
+
         def guard_image( result )
           result ? :success : :failed
         end
-        
+
         def notify( result, duration )
           message = guard_message( result, duration )
           image   = guard_image( result )
-          
-          ::Guard::Notifier.notify( message, :title => 'Annotate complete', :image => image )
-        end     
+
+          Compat::UI.notify( message, :title => 'Annotate complete', :image => image )
+        end
       end
-      
+
     end
   end
 end

--- a/spec/guard/annotate_spec.rb
+++ b/spec/guard/annotate_spec.rb
@@ -3,6 +3,10 @@ require 'guard/annotate'
 RSpec.describe Guard::Annotate do
   subject { Guard::Annotate.new }
 
+  before do
+    allow(Guard::UI).to receive(:info)
+  end
+
   context "#initialize options" do
     describe "notify" do
       it "should be true by default" do

--- a/spec/guard/annotate_spec.rb
+++ b/spec/guard/annotate_spec.rb
@@ -6,7 +6,7 @@ describe Guard::Annotate do
   context "#initialize options" do
     describe "notify" do
       it "should be true by default" do
-        expect(subject).to be_notify
+        expect(subject.send(:notify?)).to be(true)
       end
 
       it "should allow notifications to be turned off" do
@@ -73,7 +73,7 @@ describe Guard::Annotate do
         subject.start
       end
     end
-    
+
     describe "sort columns by name" do
       it "should not sort columns by name by default" do
         expect(subject.options[:sort]).to be_falsey
@@ -157,7 +157,7 @@ describe Guard::Annotate do
         end
       end
     end
-    
+
     describe "run_at_start" do
       it "should run at start by default" do
         expect(subject.options[:run_at_start]).to be_truthy

--- a/spec/guard/annotate_spec.rb
+++ b/spec/guard/annotate_spec.rb
@@ -6,153 +6,153 @@ describe Guard::Annotate do
   context "#initialize options" do
     describe "notify" do
       it "should be true by default" do
-        subject.should be_notify
+        expect(subject).to be_notify
       end
 
       it "should allow notifications to be turned off" do
         subject = Guard::Annotate.new(:notify => false)
-        subject.options[:notify].should be_false
+        expect(subject.options[:notify]).to be_falsey
       end
     end
 
     describe "position" do
       it "should use 'before' position by default" do
-        subject.options[:position].should == 'before'
+        expect(subject.options[:position]).to eq('before')
       end
 
       it "should allow user to customize position (before)" do
         subject = Guard::Annotate.new(:position => 'before')
-        subject.options[:position].should == 'before'
-        subject.should_receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before")
+        expect(subject.options[:position]).to eq('before')
+        expect(subject).to receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before")
         subject.start
       end
 
       it "should allow user to customize position (after)" do
         subject = Guard::Annotate.new(:position => 'after')
-        subject.options[:position].should == 'after'
-        subject.should_receive(:system).with("bundle exec annotate --exclude tests,fixtures -p after")
+        expect(subject.options[:position]).to eq('after')
+        expect(subject).to receive(:system).with("bundle exec annotate --exclude tests,fixtures -p after")
         subject.start
       end
     end
 
     describe "routes" do
       it "should not run routes by default" do
-        subject.options[:routes].should be_false
+        expect(subject.options[:routes]).to be_falsey
       end
 
       it "should allow the users to run routes if desired" do
         subject = Guard::Annotate.new(:routes => true)
-        subject.should_receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before")
-        subject.should_receive(:system).with("bundle exec annotate -r -p before")
+        expect(subject).to receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before")
+        expect(subject).to receive(:system).with("bundle exec annotate -r -p before")
         subject.start
       end
 
       it "should allow the user to customize routes annotation position (before)" do
         subject = Guard::Annotate.new(:routes => true, :position => 'before')
-        subject.should_receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before")
-        subject.should_receive(:system).with("bundle exec annotate -r -p before")
+        expect(subject).to receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before")
+        expect(subject).to receive(:system).with("bundle exec annotate -r -p before")
         subject.start
       end
 
       it "should allow the user to customize routes annotation position (after)" do
         subject = Guard::Annotate.new(:routes => true, :position => 'after')
-        subject.should_receive(:system).with("bundle exec annotate --exclude tests,fixtures -p after")
-        subject.should_receive(:system).with("bundle exec annotate -r -p after")
+        expect(subject).to receive(:system).with("bundle exec annotate --exclude tests,fixtures -p after")
+        expect(subject).to receive(:system).with("bundle exec annotate -r -p after")
         subject.start
       end
     end
 
     describe "tests & fixtures" do
       it "should not run tests annotations by default" do
-        subject.options[:tests].should be_false
+        expect(subject.options[:tests]).to be_falsey
       end
 
       it "should allow user to run tests and fixtures annotations if desired" do
         subject = Guard::Annotate.new(:tests => true)
-        subject.should_receive(:system).with("bundle exec annotate  -p before")
+        expect(subject).to receive(:system).with("bundle exec annotate  -p before")
         subject.start
       end
     end
     
     describe "sort columns by name" do
       it "should not sort columns by name by default" do
-        subject.options[:sort].should be_false
+        expect(subject.options[:sort]).to be_falsey
       end
 
       it "should allow user to sort columns by name if desired" do
         subject = Guard::Annotate.new(:sort => true)
-        subject.should_receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before --sort")
+        expect(subject).to receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before --sort")
         subject.start
       end
     end
 
     describe "indexes" do
       it "should not add indexes to annotations by default" do
-        subject.options[:show_indexes].should be_false
+        expect(subject.options[:show_indexes]).to be_falsey
       end
 
       it "should allow user to add indexes to annotations if desired" do
         subject = Guard::Annotate.new(:show_indexes => true)
-        subject.should_receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before --show-indexes")
+        expect(subject).to receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before --show-indexes")
         subject.start
       end
     end
 
     describe "simple indexes" do
       it "should not add simple indexes to annotations by default" do
-        subject.options[:simple_indexes].should be_false
+        expect(subject.options[:simple_indexes]).to be_falsey
       end
 
       it "should allow user to add simple indexes to annotations if desired" do
         subject = Guard::Annotate.new(:simple_indexes => true)
-        subject.should_receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before --simple-indexes")
+        expect(subject).to receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before --simple-indexes")
         subject.start
       end
     end
 
     describe "show migration" do
       it "should not show migration version in annotations by default" do
-        subject.options[:show_migration].should be_false
+        expect(subject.options[:show_migration]).to be_falsey
       end
 
       it "should allow user to add migration version in annotations if desired" do
         subject = Guard::Annotate.new(:show_migration => true)
-        subject.should_receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before --show-migration")
+        expect(subject).to receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before --show-migration")
         subject.start
       end
     end
 
     describe "annotation format" do
       it "should not add format type to annotations by default" do
-        subject.options[:show_migration].should be_false
+        expect(subject.options[:show_migration]).to be_falsey
       end
 
       describe "invalid" do
         it "should not add format type if option given is invalid" do
           subject = Guard::Annotate.new(:format => :invalid_option)
-          subject.options[:show_migration].should be_false
-          subject.should_receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before")
+          expect(subject.options[:show_migration]).to be_falsey
+          expect(subject).to receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before")
           subject.start
         end
       end
       describe "bare" do
         it "should allow user to choose format of annotations if desired" do
           subject = Guard::Annotate.new(:format => :bare)
-          subject.should_receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before --format=bare")
+          expect(subject).to receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before --format=bare")
           subject.start
         end
       end
       describe "rdoc" do
         it "should allow user to choose format of annotations if desired" do
           subject = Guard::Annotate.new(:format => :rdoc)
-          subject.should_receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before --format=rdoc")
+          expect(subject).to receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before --format=rdoc")
           subject.start
         end
       end
       describe "markdown" do
         it "should allow user to choose format of annotations if desired" do
           subject = Guard::Annotate.new(:format => :markdown)
-          subject.should_receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before --format=markdown")
+          expect(subject).to receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before --format=markdown")
           subject.start
         end
       end
@@ -160,29 +160,29 @@ describe Guard::Annotate do
     
     describe "run_at_start" do
       it "should run at start by default" do
-        subject.options[:run_at_start].should be_true
+        expect(subject.options[:run_at_start]).to be_truthy
       end
 
       it "should allow user to opt out of running at start" do
         subject = Guard::Annotate.new(:run_at_start => false)
-        subject.options[:run_at_start].should be_false
+        expect(subject.options[:run_at_start]).to be_falsey
       end
     end
   end
 
   context "start" do
     it "should run annotate command" do
-      subject.should_receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before")
+      expect(subject).to receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before")
       subject.start
     end
 
     it "should return false if annotate command fails" do
-      subject.should_receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before").and_return(false)
-      subject.start.should be_false
+      expect(subject).to receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before").and_return(false)
+      expect(subject.start).to be_falsey
     end
 
     it 'should not run annotate command if disabled :run_at_start' do
-      subject.should_not_receive(:system)
+      expect(subject).not_to receive(:system)
       subject.options[:run_at_start] = false
       subject.start
     end
@@ -190,23 +190,23 @@ describe Guard::Annotate do
 
   context "stop" do
     it "should be a noop (return true)" do
-      subject.stop.should be_true
+      expect(subject.stop).to be_truthy
     end
   end
 
   context "reload" do
     it "should run annotate command" do
-      subject.should_receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before")
+      expect(subject).to receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before")
       subject.reload
     end
 
     it "should return false if annotate command fails" do
-      subject.should_receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before").and_return(false)
-      subject.reload.should be_false
+      expect(subject).to receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before").and_return(false)
+      expect(subject.reload).to be_falsey
     end
 
     it 'should not run annotate command if disabled :run_at_start' do
-      subject.should_not_receive(:system)
+      expect(subject).not_to receive(:system)
       subject.options[:run_at_start] = false
       subject.reload
     end
@@ -214,20 +214,20 @@ describe Guard::Annotate do
 
   context "run_all" do
     it "should be a noop (return true)" do
-      subject.run_all.should be_true
+      expect(subject.run_all).to be_truthy
     end
   end
 
   # For Guard 1.1. #run_on_change is deprecated
   context "run_on_changes" do
     it "should run annotate command" do
-      subject.should_receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before")
+      expect(subject).to receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before")
       subject.run_on_changes
     end
 
     it "should return false if annotate command fails" do
-      subject.should_receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before").and_return(false)
-      subject.run_on_changes.should be_false
+      expect(subject).to receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before").and_return(false)
+      expect(subject.run_on_changes).to be_falsey
     end
   end
 end

--- a/spec/guard/annotate_spec.rb
+++ b/spec/guard/annotate_spec.rb
@@ -1,6 +1,6 @@
-require 'spec_helper'
+require 'guard/annotate'
 
-describe Guard::Annotate do
+RSpec.describe Guard::Annotate do
   subject { Guard::Annotate.new }
 
   context "#initialize options" do

--- a/spec/guard/annotate_spec.rb
+++ b/spec/guard/annotate_spec.rb
@@ -1,10 +1,13 @@
+require 'guard/compat/test/helper'
+
 require 'guard/annotate'
 
 RSpec.describe Guard::Annotate do
   subject { Guard::Annotate.new }
 
   before do
-    allow(Guard::UI).to receive(:info)
+    allow(Guard::Compat::UI).to receive(:info)
+    allow(Guard::Compat::UI).to receive(:notify)
   end
 
   context "#initialize options" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,14 +7,8 @@ RSpec.configure do |c|
   c.color_enabled = true
   c.filter_run :focus => true
   c.run_all_when_everything_filtered = true
-  
+
   c.before( :each ) do
-    ENV["GUARD_ENV"] = "test"
     ::Guard::Notifier.stub( :notify ).and_return( true )
-    @lib_path = Pathname.new( File.expand_path( '../../lib/', __FILE__ ) )
-  end
-  
-  c.after( :each ) do
-    ENV["GUARD_ENV"] = nil
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,13 +1,24 @@
-require 'rspec'
-require 'guard/annotate'
-
-Dir["#{File.expand_path('..', __FILE__)}/support/**/*.rb"].each { |f| require f }
-
-RSpec.configure do |c|
-  c.filter_run :focus => true
-  c.run_all_when_everything_filtered = true
-
-  c.before( :each ) do
-    allow(::Guard::Notifier).to receive( :notify ).and_return( true )
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.filter_run :focus
+  config.run_all_when_everything_filtered = true
+
+  config.disable_monkey_patching!
+
+  # config.warnings = true
+
+  config.default_formatter = 'doc' if config.files_to_run.one?
+
+  # config.profile_examples = 10
+
+  config.order = :random
+
+  Kernel.srand config.seed
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,6 @@ RSpec.configure do |c|
   c.run_all_when_everything_filtered = true
 
   c.before( :each ) do
-    ::Guard::Notifier.stub( :notify ).and_return( true )
+    allow(::Guard::Notifier).to receive( :notify ).and_return( true )
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,6 @@ require 'guard/annotate'
 Dir["#{File.expand_path('..', __FILE__)}/support/**/*.rb"].each { |f| require f }
 
 RSpec.configure do |c|
-  c.color_enabled = true
   c.filter_run :focus => true
   c.run_all_when_everything_filtered = true
 


### PR DESCRIPTION
- fixes broken test (due to Guard internals changing)
- Guard::Compat should from future incompatibility issues
- updated spec for RSpec 3
- minor project updates here and there
- no dependency on guard (not necessary anymore)